### PR TITLE
adds a useCallback demo with a heavy function on each render

### DIFF
--- a/src/components/screens/Home/Home.tsx
+++ b/src/components/screens/Home/Home.tsx
@@ -4,6 +4,7 @@ import { PowerSettingsNew } from "@material-ui/icons";
 import actions from "context/AuthContext/actions";
 import { AuthContext } from "context/AuthContext/AuthContext";
 import { logout } from "services/authentication";
+import UseCallbackDemo from "../components/EmailTextField/UseCallbackDemo/UseCallbackDemo";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -30,7 +31,8 @@ const Home: React.FC = () => {
 
   return (
     <div className={classes.root}>
-      Logged In
+      <UseCallbackDemo />
+      <div>Logged In</div>
       <IconButton aria-label="sign out" onClick={handleLogout}>
         <PowerSettingsNew />
       </IconButton>

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/UseCallbackDemo.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/UseCallbackDemo.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Grid, makeStyles, Paper } from "@material-ui/core";
+import UnoptimizedCounter from "./components/UnoptimizedCounter/UnoptimizedCounter";
+import OptimizedCounter from "./components/OptimizedCounter/OptimizedCounter";
+import PaperContainer from "./components/PaperContainer/PaperContainer";
+
+const UseCallbackDemo: React.FC = () => {
+  return (
+    <Grid container alignItems="center" justify="center">
+      <PaperContainer title="Unoptimized Component">
+        <UnoptimizedCounter />
+      </PaperContainer>
+      <PaperContainer title="Optimized Component with useCallback">
+        <OptimizedCounter />
+      </PaperContainer>
+    </Grid>
+  );
+};
+
+export default UseCallbackDemo;

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/MemoizedButton/MemoizedButton.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/MemoizedButton/MemoizedButton.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@material-ui/core";
+import React, { useEffect, useRef } from "react";
+
+interface MemoizedButtonProps {
+  increment: (event: React.MouseEvent) => void;
+}
+
+const MemoizedButton: React.FC<MemoizedButtonProps> = React.memo(
+  ({ increment }) => {
+    const timesRendered = useRef(0);
+    timesRendered.current++;
+
+    const heavyFunction = () => {
+      let count = 0;
+      while (count < 2000000000) {
+        count++;
+      }
+    };
+
+    useEffect(() => {
+      heavyFunction();
+    });
+
+    return (
+      <Button onClick={increment} variant="contained" color="primary">
+        Press Me, I've Rendered {timesRendered.current} times
+      </Button>
+    );
+  }
+);
+
+export default MemoizedButton;

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/MemoizedButton/MemoizedButton.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/MemoizedButton/MemoizedButton.tsx
@@ -5,14 +5,17 @@ interface MemoizedButtonProps {
   increment: (event: React.MouseEvent) => void;
 }
 
+const INITIAL_RENDER_TIMES = 0;
+const MAX_LOOP_COUNT_FOR_HEAVY_FUNCTION = 2000000000;
+
 const MemoizedButton: React.FC<MemoizedButtonProps> = React.memo(
   ({ increment }) => {
-    const timesRendered = useRef(0);
+    const timesRendered = useRef(INITIAL_RENDER_TIMES);
     timesRendered.current++;
 
     const heavyFunction = () => {
       let count = 0;
-      while (count < 2000000000) {
+      while (count <= MAX_LOOP_COUNT_FOR_HEAVY_FUNCTION) {
         count++;
       }
     };

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/OptimizedCounter/OptimizedCounter.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/OptimizedCounter/OptimizedCounter.tsx
@@ -1,21 +1,22 @@
 import React, { useCallback, useState } from "react";
 import MemoizedButton from "../MemoizedButton/MemoizedButton";
+import { INITIAL_BUTTON_CLICKED_TIMES } from "../constants";
 
 const OptimizedCounter: React.FC = () => {
-  const [timesMemoizedBtnClicked, setTimesMemoizedBtnClicked] = useState(0);
+  const [timesMemoizedButtonClicked, setTimesMemoizedButtonClicked] = useState(
+    INITIAL_BUTTON_CLICKED_TIMES
+  );
 
   const incrementMemoizedButtonClicks = useCallback(
     (e: React.MouseEvent) => {
-      setTimesMemoizedBtnClicked(
-        (TimesMemoBtnClicked) => TimesMemoBtnClicked + 1
-      );
+      setTimesMemoizedButtonClicked((actualValue) => actualValue + 1);
     },
-    [setTimesMemoizedBtnClicked]
+    [setTimesMemoizedButtonClicked]
   );
 
   return (
     <>
-      <div>You've clicked the button {timesMemoizedBtnClicked} times</div>
+      <div>You've clicked the button {timesMemoizedButtonClicked} times</div>
       <MemoizedButton increment={incrementMemoizedButtonClicks} />
     </>
   );

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/OptimizedCounter/OptimizedCounter.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/OptimizedCounter/OptimizedCounter.tsx
@@ -1,0 +1,24 @@
+import React, { useCallback, useState } from "react";
+import MemoizedButton from "../MemoizedButton/MemoizedButton";
+
+const OptimizedCounter: React.FC = () => {
+  const [timesMemoizedBtnClicked, setTimesMemoizedBtnClicked] = useState(0);
+
+  const incrementMemoizedButtonClicks = useCallback(
+    (e: React.MouseEvent) => {
+      setTimesMemoizedBtnClicked(
+        (TimesMemoBtnClicked) => TimesMemoBtnClicked + 1
+      );
+    },
+    [setTimesMemoizedBtnClicked]
+  );
+
+  return (
+    <>
+      <div>You've clicked the button {timesMemoizedBtnClicked} times</div>
+      <MemoizedButton increment={incrementMemoizedButtonClicks} />
+    </>
+  );
+};
+
+export default OptimizedCounter;

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/PaperContainer/PaperContainer.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/PaperContainer/PaperContainer.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Grid, makeStyles, Paper } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  gridItem: {
+    padding: ".7em",
+  },
+  paper: {
+    background: theme.palette.background.paper,
+    padding: "1em",
+    textAlign: "center",
+    "& > *": {
+      margin: ".5em",
+    },
+  },
+}));
+
+interface PaperContainerProps {
+  children: React.ReactNode;
+  title: string;
+}
+
+const PaperContainer: React.FC<PaperContainerProps> = ({ children, title }) => {
+  const classes = useStyles();
+  return (
+    <Grid item xs={11} md={5} className={classes.gridItem}>
+      <Paper className={classes.paper}>
+        <div>
+          <b>{title}</b>
+        </div>
+        {children}
+      </Paper>
+    </Grid>
+  );
+};
+
+export default PaperContainer;

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/UnoptimizedCounter/UnoptimizedCounter.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/UnoptimizedCounter/UnoptimizedCounter.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from "react";
+import MemoizedButton from "../MemoizedButton/MemoizedButton";
+
+const UnoptimizedCounter: React.FC = () => {
+  const [timesMemoizedButtonClicked, setTimesMemoizedButtonClicked] = useState(
+    0
+  );
+
+  const incrementMemoizedButtonClicks = (e: React.MouseEvent) => {
+    setTimesMemoizedButtonClicked(
+      (TimesMemoBtnClicked) => TimesMemoBtnClicked + 1
+    );
+  };
+
+  return (
+    <>
+      <div>You've clicked the button {timesMemoizedButtonClicked} times</div>
+      <MemoizedButton increment={incrementMemoizedButtonClicks} />
+    </>
+  );
+};
+
+export default UnoptimizedCounter;

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/UnoptimizedCounter/UnoptimizedCounter.tsx
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/UnoptimizedCounter/UnoptimizedCounter.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from "react";
 import MemoizedButton from "../MemoizedButton/MemoizedButton";
+import { INITIAL_BUTTON_CLICKED_TIMES } from "../constants";
 
 const UnoptimizedCounter: React.FC = () => {
   const [timesMemoizedButtonClicked, setTimesMemoizedButtonClicked] = useState(
-    0
+    INITIAL_BUTTON_CLICKED_TIMES
   );
 
   const incrementMemoizedButtonClicks = (e: React.MouseEvent) => {
-    setTimesMemoizedButtonClicked(
-      (TimesMemoBtnClicked) => TimesMemoBtnClicked + 1
-    );
+    setTimesMemoizedButtonClicked((actualValue) => actualValue + 1);
   };
 
   return (

--- a/src/components/screens/components/EmailTextField/UseCallbackDemo/components/constants.ts
+++ b/src/components/screens/components/EmailTextField/UseCallbackDemo/components/constants.ts
@@ -1,0 +1,1 @@
+export const INITIAL_BUTTON_CLICKED_TIMES = 0;


### PR DESCRIPTION
Just added a useCallback demo with two "paper cards".

- Each paper card has a Memoized Button (a component that uses React.memo and returns a Button), with a long-to-finish function that executes on every render.
- Also Each paper card has the increment function, which is given to memoized button to call whenever it's clicked.
- Increment function when called, alters the state of the paper card where its implemented, thus, re-renders paper card, re-creates increment function, and re-renders Memoized button as consecuence.

In action:
![gif](https://media.giphy.com/media/FlwdCj4qjiyiBgrVxX/giphy.gif)

As you can see, clicking on left button, with a unoptimized container, will re-render an execute the long-to-finish function on the memoized button, which causes UI freezing.

Clicking on right button with optimized container, will not re-render memoized button as increment function is just being re-created and not changed at all.

ps: sorry for gif's low quality, here you can see [gif on google drive](https://drive.google.com/file/d/1FhERrxcvRBO1VjcJDvR9lnteYjNLNabN/view?usp=sharing).